### PR TITLE
Moved BenchmarkTools to extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+- moved BenchmarkTools to extras as test-only dependency
 
 ## [1.0.1] - 2021-07-15
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,9 @@
 name = "Continuables"
 uuid = "79afa230-ca09-11e8-120b-5decf7bf5e25"
 authors = ["Sahm Stephan <stephan.sahm@gmx.de>"]
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DataTypesBasic = "83eed652-29e8-11e9-12da-a7c29d64ffc9"
 ExprParsers = "c5caad1f-83bd-4ce8-ac8e-4b29921e994e"
@@ -12,16 +11,16 @@ OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 SimpleMatch = "a3ae8450-d22f-11e9-3fe0-77240e25996f"
 
 [compat]
-BenchmarkTools = "0.5, 1"
 Compat = "2.1, 3"
 DataTypesBasic = "1, 2"
 ExprParsers = "1.0"
-julia = "1"
 OrderedCollections = "1.3"
 SimpleMatch = "1.0"
+julia = "1"
 
 [extras]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "BenchmarkTools"]


### PR DESCRIPTION
BenchmarkTools was not being used as part of the package source code, so I moved it to the extras section to avoid having it as an unnecessary main dependecy for final users.

Also updated version to 1.0.2 following semver and added an entry on the changelog about moving BenchmarkTools to extras.